### PR TITLE
[codex] Expose chain registry summary metadata

### DIFF
--- a/src/chainSummary.ts
+++ b/src/chainSummary.ts
@@ -1,0 +1,23 @@
+import type { ChainEntry, ChainSummary } from './types.ts';
+
+export function summarizeChains(chainsData: Record<string, ChainEntry>): ChainSummary[] {
+	return Object.entries(chainsData)
+		.map(([name, data]) => {
+			const rpcCount = data.rpcAddresses.length;
+			const restCount = data.restAddresses?.length || 0;
+
+			return {
+				name,
+				chainId: data.chainId,
+				bech32Prefix: data.bech32Prefix,
+				endpointCount: rpcCount + restCount,
+				rpcCount,
+				restCount,
+				source: 'chain-registry' as const,
+				timestamp: data.timestamp,
+				lastUpdated: data.lastUpdated,
+				lastCrawled: data.lastCrawled,
+			};
+		})
+		.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 	proxyWithCaching,
 } from './balancer.ts';
 import { flushCache, getCacheStats } from './cacheManager.ts';
+import { summarizeChains } from './chainSummary.ts';
 import config from './config.ts';
 import { crawlAllChains, crawlNetwork } from './crawler.ts';
 import dataService from './dataService.ts';
@@ -105,13 +106,7 @@ api.get('/chain-list', async (c) => {
 
 api.get('/chains-summary', async (c) => {
 	const chainsData = await dataService.loadChainsData();
-	const summary = Object.entries(chainsData).map(([name, data]) => ({
-		name,
-		endpointCount: data.rpcAddresses.length + (data.restAddresses?.length || 0),
-		rpcCount: data.rpcAddresses.length,
-		restCount: data.restAddresses?.length || 0,
-	}));
-	return c.json(summary);
+	return c.json(summarizeChains(chainsData));
 });
 
 api.get('/rpc-list/:chainName', async (c) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,19 @@ export interface ChainEntry {
 	lastCrawled?: string;
 }
 
+export interface ChainSummary {
+	name: string;
+	chainId: string;
+	bech32Prefix: string;
+	endpointCount: number;
+	rpcCount: number;
+	restCount: number;
+	source: 'chain-registry';
+	timestamp?: number;
+	lastUpdated?: string;
+	lastCrawled?: string;
+}
+
 export interface NetInfo {
 	peers: Peer[];
 }

--- a/tests/chainSummary.test.ts
+++ b/tests/chainSummary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeChains } from '../src/chainSummary';
+
+describe('chain summaries', () => {
+	it('includes registry metadata and endpoint counts for chain selection', () => {
+		expect(
+			summarizeChains({
+				cosmoshub: {
+					chainName: 'cosmoshub',
+					chainId: 'cosmoshub-4',
+					bech32Prefix: 'cosmos',
+					rpcAddresses: ['https://rpc.example.com'],
+					restAddresses: ['https://rest.example.com', 'https://rest2.example.com'],
+					timestamp: 1700000000000,
+				},
+			})
+		).toEqual([
+			{
+				name: 'cosmoshub',
+				chainId: 'cosmoshub-4',
+				bech32Prefix: 'cosmos',
+				endpointCount: 3,
+				rpcCount: 1,
+				restCount: 2,
+				source: 'chain-registry',
+				timestamp: 1700000000000,
+			},
+		]);
+	});
+
+	it('sorts summaries by chain name', () => {
+		expect(
+			summarizeChains({
+				osmosis: {
+					chainName: 'osmosis',
+					chainId: 'osmosis-1',
+					bech32Prefix: 'osmo',
+					rpcAddresses: ['https://rpc.osmosis.example.com'],
+					restAddresses: [],
+				},
+				cosmoshub: {
+					chainName: 'cosmoshub',
+					chainId: 'cosmoshub-4',
+					bech32Prefix: 'cosmos',
+					rpcAddresses: ['https://rpc.cosmos.example.com'],
+					restAddresses: ['https://rest.cosmos.example.com'],
+				},
+			}).map((chain) => chain.name)
+		).toEqual(['cosmoshub', 'osmosis']);
+	});
+});


### PR DESCRIPTION
## Summary
- add a pure chain summary helper for registry-derived metadata
- include `chainId`, `bech32Prefix`, source, and freshness fields in `/api/chains-summary`
- keep live proxy behavior unchanged; this endpoint is selection metadata only

## Validation
- `bun test`
- `bun run lint`
- `bun run build`
- deployed commit to the `ibc-escrow` LXC lazy-lb service and verified `/api/chains-summary` returns 238 chains with `cosmoshub-4` metadata
