### PR TITLE
Add IBC link resolver API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,16 @@ bun run build     # Bundle src/index.ts for Bun
    curl http://localhost:3000/api/chains-summary
    ```
 
-3. Get endpoint lists for a specific chain:
+3. Resolve IBC channel links between two chains by chain name or chain ID:
+   ```bash
+   curl 'http://localhost:3000/api/ibc-links?source=genesis_29-2&destination=osmosis-1'
+   ```
+
+   The response is sorted with preferred live registry links first and includes
+   source-side channel/port, counterparty channel/port, connection, client, and
+   chain ID metadata.
+
+4. Get endpoint lists for a specific chain:
    ```bash
    curl http://localhost:3000/api/rpc-list/osmosis
    ```

--- a/src/ibcLinks.ts
+++ b/src/ibcLinks.ts
@@ -1,0 +1,260 @@
+import { REPO_NAME, REPO_OWNER } from './config.ts';
+import { appLogger as logger } from './logger.ts';
+import type {
+	ChainEntry,
+	GithubContent,
+	IbcLink,
+	IbcLinkResolutionResult,
+	IbcRegistryFile,
+} from './types.ts';
+
+interface RegistryFileInput {
+	name: string;
+	data: IbcRegistryFile;
+}
+
+interface ResolveFromFilesOptions {
+	source: string;
+	destination: string;
+	chainsData: Record<string, ChainEntry>;
+	files: RegistryFileInput[];
+}
+
+interface ResolveFromRegistryOptions {
+	source: string;
+	destination: string;
+	chainsData: Record<string, ChainEntry>;
+	fetchFn?: typeof fetch;
+	now?: () => number;
+}
+
+const IBC_CACHE_TTL_MS = 10 * 60 * 1000;
+const GITHUB_CONTENTS_URL = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/_IBC`;
+const RAW_IBC_BASE_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/master/_IBC`;
+
+let directoryCache: { expiresAt: number; files: GithubContent[] } | null = null;
+const fileCache = new Map<string, { expiresAt: number; data: IbcRegistryFile }>();
+
+function normalizeChainKey(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function chainIdFor(name: string, chainsData: Record<string, ChainEntry>): string {
+	return chainsData[name]?.chainId || '';
+}
+
+export function resolveChainAlias(
+	input: string,
+	chainsData: Record<string, ChainEntry>
+): string | null {
+	const normalizedInput = normalizeChainKey(input);
+	if (!normalizedInput) return null;
+
+	for (const [name, chain] of Object.entries(chainsData)) {
+		const aliases = [name, chain.chainName, chain.chainId].map(normalizeChainKey);
+		if (aliases.includes(normalizedInput)) {
+			return name;
+		}
+	}
+
+	return null;
+}
+
+function compareLinks(a: IbcLink, b: IbcLink): number {
+	const preferredDelta = Number(b.tags.preferred === true) - Number(a.tags.preferred === true);
+	if (preferredDelta !== 0) return preferredDelta;
+
+	const activeDelta = Number(isActiveStatus(b.tags.status)) - Number(isActiveStatus(a.tags.status));
+	if (activeDelta !== 0) return activeDelta;
+
+	const transferDelta = Number(b.portId === 'transfer') - Number(a.portId === 'transfer');
+	if (transferDelta !== 0) return transferDelta;
+
+	return `${a.destinationChainName}:${a.channelId}`.localeCompare(
+		`${b.destinationChainName}:${b.channelId}`
+	);
+}
+
+function isActiveStatus(status: string | undefined): boolean {
+	const normalized = status?.trim().toUpperCase();
+	return normalized === 'ACTIVE' || normalized === 'LIVE';
+}
+
+function mapRegistryFile(
+	file: RegistryFileInput,
+	sourceName: string,
+	destinationName: string,
+	chainsData: Record<string, ChainEntry>
+): IbcLink[] {
+	const chain1Name = normalizeChainKey(file.data.chain_1.chain_name);
+	const chain2Name = normalizeChainKey(file.data.chain_2.chain_name);
+	const sourceKey = normalizeChainKey(sourceName);
+	const destinationKey = normalizeChainKey(destinationName);
+
+	let sourceSide: 'chain_1' | 'chain_2' | null = null;
+	if (chain1Name === sourceKey && chain2Name === destinationKey) {
+		sourceSide = 'chain_1';
+	} else if (chain2Name === sourceKey && chain1Name === destinationKey) {
+		sourceSide = 'chain_2';
+	}
+
+	if (!sourceSide) {
+		return [];
+	}
+
+	const counterpartySide = sourceSide === 'chain_1' ? 'chain_2' : 'chain_1';
+	const sourceChain = file.data[sourceSide];
+	const counterpartyChain = file.data[counterpartySide];
+
+	return file.data.channels.map((channel) => {
+		const sourceChannel = channel[sourceSide];
+		const counterpartyChannel = channel[counterpartySide];
+
+		return {
+			sourceChainName: sourceName,
+			sourceChainId: chainIdFor(sourceName, chainsData),
+			destinationChainName: destinationName,
+			destinationChainId: chainIdFor(destinationName, chainsData),
+			channelId: sourceChannel.channel_id,
+			portId: sourceChannel.port_id || 'transfer',
+			counterpartyChannelId: counterpartyChannel.channel_id,
+			counterpartyPortId: counterpartyChannel.port_id || 'transfer',
+			clientId: sourceChannel.client_id || sourceChain.client_id,
+			counterpartyClientId: counterpartyChannel.client_id || counterpartyChain.client_id,
+			connectionId: sourceChannel.connection_id || sourceChain.connection_id,
+			counterpartyConnectionId:
+				counterpartyChannel.connection_id || counterpartyChain.connection_id,
+			ordering: channel.ordering,
+			version: channel.version,
+			tags: channel.tags || {},
+			sourceFile: file.name,
+		};
+	});
+}
+
+export function resolveIbcLinksFromRegistryFiles({
+	source,
+	destination,
+	chainsData,
+	files,
+}: ResolveFromFilesOptions): IbcLinkResolutionResult {
+	const sourceName = resolveChainAlias(source, chainsData);
+	if (!sourceName) {
+		throw new Error(`Unknown source chain: ${source}`);
+	}
+
+	const destinationName = resolveChainAlias(destination, chainsData);
+	if (!destinationName) {
+		throw new Error(`Unknown destination chain: ${destination}`);
+	}
+
+	const links = files
+		.flatMap((file) => mapRegistryFile(file, sourceName, destinationName, chainsData))
+		.sort(compareLinks);
+
+	return {
+		source: {
+			name: sourceName,
+			chainId: chainIdFor(sourceName, chainsData),
+		},
+		destination: {
+			name: destinationName,
+			chainId: chainIdFor(destinationName, chainsData),
+		},
+		links,
+	};
+}
+
+function isCandidateIbcFile(
+	fileName: string,
+	sourceName: string,
+	destinationName: string
+): boolean {
+	const baseName = fileName.replace(/\.json$/i, '').toLowerCase();
+	const source = normalizeChainKey(sourceName);
+	const destination = normalizeChainKey(destinationName);
+	return baseName === `${source}-${destination}` || baseName === `${destination}-${source}`;
+}
+
+async function fetchJson<T>(url: string, fetchFn: typeof fetch): Promise<T> {
+	const response = await fetchFn(url);
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status} from ${url}`);
+	}
+
+	return (await response.json()) as T;
+}
+
+async function fetchIbcDirectory(
+	fetchFn: typeof fetch,
+	now: () => number
+): Promise<GithubContent[]> {
+	if (directoryCache && directoryCache.expiresAt > now()) {
+		return directoryCache.files;
+	}
+
+	const contents = await fetchJson<GithubContent[]>(GITHUB_CONTENTS_URL, fetchFn);
+	const files = contents.filter(
+		(item) => item.type === 'file' && item.name.toLowerCase().endsWith('.json')
+	);
+	directoryCache = {
+		files,
+		expiresAt: now() + IBC_CACHE_TTL_MS,
+	};
+	return files;
+}
+
+async function fetchIbcFile(
+	file: GithubContent,
+	fetchFn: typeof fetch,
+	now: () => number
+): Promise<RegistryFileInput> {
+	const cached = fileCache.get(file.name);
+	if (cached && cached.expiresAt > now()) {
+		return { name: file.name, data: cached.data };
+	}
+
+	const url = file.download_url || `${RAW_IBC_BASE_URL}/${encodeURIComponent(file.name)}`;
+	const data = await fetchJson<IbcRegistryFile>(url, fetchFn);
+	fileCache.set(file.name, {
+		data,
+		expiresAt: now() + IBC_CACHE_TTL_MS,
+	});
+	return { name: file.name, data };
+}
+
+export async function resolveIbcLinksFromChainRegistry({
+	source,
+	destination,
+	chainsData,
+	fetchFn = fetch,
+	now = () => Date.now(),
+}: ResolveFromRegistryOptions): Promise<IbcLinkResolutionResult> {
+	const sourceName = resolveChainAlias(source, chainsData);
+	if (!sourceName) {
+		throw new Error(`Unknown source chain: ${source}`);
+	}
+
+	const destinationName = resolveChainAlias(destination, chainsData);
+	if (!destinationName) {
+		throw new Error(`Unknown destination chain: ${destination}`);
+	}
+
+	const directory = await fetchIbcDirectory(fetchFn, now);
+	const candidates = directory.filter((file) =>
+		isCandidateIbcFile(file.name, sourceName, destinationName)
+	);
+	const files = await Promise.all(candidates.map((file) => fetchIbcFile(file, fetchFn, now)));
+
+	return resolveIbcLinksFromRegistryFiles({
+		source: sourceName,
+		destination: destinationName,
+		chainsData,
+		files,
+	});
+}
+
+export function clearIbcLinkCaches(): void {
+	directoryCache = null;
+	fileCache.clear();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { summarizeChains } from './chainSummary.ts';
 import config from './config.ts';
 import { crawlAllChains, crawlNetwork } from './crawler.ts';
 import dataService from './dataService.ts';
+import { resolveIbcLinksFromChainRegistry } from './ibcLinks.ts';
 import { appLogger as logger } from './logger.ts';
 import SchedulerService from './scheduler.ts';
 import type { ChainConfig, GlobalConfig } from './types.ts';
@@ -107,6 +108,35 @@ api.get('/chain-list', async (c) => {
 api.get('/chains-summary', async (c) => {
 	const chainsData = await dataService.loadChainsData();
 	return c.json(summarizeChains(chainsData));
+});
+
+api.get('/ibc-links', async (c) => {
+	const source = c.req.query('source')?.trim();
+	const destination = c.req.query('destination')?.trim();
+	if (!source || !destination) {
+		return c.json({ error: 'Query parameters source and destination are required' }, 400);
+	}
+
+	try {
+		const chainsData = await dataService.loadChainsData();
+		const links = await resolveIbcLinksFromChainRegistry({
+			source,
+			destination,
+			chainsData,
+		});
+		return c.json(links);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Failed to resolve IBC links';
+		if (
+			message.startsWith('Unknown source chain') ||
+			message.startsWith('Unknown destination chain')
+		) {
+			return c.json({ error: message }, 404);
+		}
+
+		logger.error('Failed to resolve IBC links', err);
+		return c.json({ error: message }, 500);
+	}
 });
 
 api.get('/rpc-list/:chainName', async (c) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,71 @@ export interface ChainSummary {
 	lastCrawled?: string;
 }
 
+export interface IbcRegistryChainSide {
+	chain_name: string;
+	client_id: string;
+	connection_id: string;
+}
+
+export interface IbcRegistryChannelSide {
+	channel_id: string;
+	port_id?: string;
+	client_id?: string;
+	connection_id?: string;
+}
+
+export interface IbcRegistryChannelTags {
+	status?: string;
+	preferred?: boolean;
+	dex?: string;
+	properties?: string;
+}
+
+export interface IbcRegistryChannel {
+	chain_1: IbcRegistryChannelSide;
+	chain_2: IbcRegistryChannelSide;
+	ordering: string;
+	version: string;
+	tags?: IbcRegistryChannelTags;
+}
+
+export interface IbcRegistryFile {
+	chain_1: IbcRegistryChainSide;
+	chain_2: IbcRegistryChainSide;
+	channels: IbcRegistryChannel[];
+}
+
+export interface IbcLink {
+	sourceChainName: string;
+	sourceChainId: string;
+	destinationChainName: string;
+	destinationChainId: string;
+	channelId: string;
+	portId: string;
+	counterpartyChannelId: string;
+	counterpartyPortId: string;
+	clientId: string;
+	counterpartyClientId: string;
+	connectionId: string;
+	counterpartyConnectionId: string;
+	ordering: string;
+	version: string;
+	tags: IbcRegistryChannelTags;
+	sourceFile: string;
+}
+
+export interface IbcLinkResolutionResult {
+	source: {
+		name: string;
+		chainId: string;
+	};
+	destination: {
+		name: string;
+		chainId: string;
+	};
+	links: IbcLink[];
+}
+
 export interface NetInfo {
 	peers: Peer[];
 }
@@ -163,6 +228,7 @@ export enum CircuitState {
 export interface GithubContent {
 	name: string;
 	type: string;
+	download_url?: string;
 }
 
 export interface ChainRegistryData {

--- a/tests/ibcLinks.test.ts
+++ b/tests/ibcLinks.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+	clearIbcLinkCaches,
+	resolveChainAlias,
+	resolveIbcLinksFromChainRegistry,
+	resolveIbcLinksFromRegistryFiles,
+} from '../src/ibcLinks';
+import type { ChainEntry, IbcRegistryFile } from '../src/types';
+
+const chainsData: Record<string, ChainEntry> = {
+	genesisl1: {
+		chainName: 'genesisl1',
+		chainId: 'genesis_29-2',
+		bech32Prefix: 'genesis',
+		rpcAddresses: ['https://rpc.genesis.example.com'],
+		restAddresses: ['https://rest.genesis.example.com'],
+	},
+	osmosis: {
+		chainName: 'osmosis',
+		chainId: 'osmosis-1',
+		bech32Prefix: 'osmo',
+		rpcAddresses: ['https://rpc.osmosis.example.com'],
+		restAddresses: ['https://rest.osmosis.example.com'],
+	},
+};
+
+const genesisOsmosis: IbcRegistryFile = {
+	chain_1: {
+		chain_name: 'genesisl1',
+		client_id: '07-tendermint-1',
+		connection_id: 'connection-1',
+	},
+	chain_2: {
+		chain_name: 'osmosis',
+		client_id: '07-tendermint-1983',
+		connection_id: 'connection-1539',
+	},
+	channels: [
+		{
+			chain_1: {
+				channel_id: 'channel-0',
+				port_id: 'transfer',
+			},
+			chain_2: {
+				channel_id: 'channel-700',
+				port_id: 'transfer',
+			},
+			ordering: 'unordered',
+			version: 'ics20-1',
+			tags: {
+				preferred: true,
+				status: 'INACTIVE',
+			},
+		},
+		{
+			chain_1: {
+				channel_id: 'channel-1',
+				port_id: 'transfer',
+			},
+			chain_2: {
+				channel_id: 'channel-253',
+				port_id: 'transfer',
+			},
+			ordering: 'unordered',
+			version: 'ics20-1',
+			tags: {
+				status: 'ACTIVE',
+				preferred: true,
+				dex: 'osmosis',
+			},
+		},
+	],
+};
+
+describe('IBC link resolution', () => {
+	it('resolves chain names and chain IDs to canonical chain names', () => {
+		expect(resolveChainAlias('genesisl1', chainsData)).toBe('genesisl1');
+		expect(resolveChainAlias('GENESIS_29-2', chainsData)).toBe('genesisl1');
+		expect(resolveChainAlias('osmosis-1', chainsData)).toBe('osmosis');
+		expect(resolveChainAlias('unknown-1', chainsData)).toBeNull();
+	});
+
+	it('maps registry links from the source chain perspective and sorts preferred active links first', () => {
+		const result = resolveIbcLinksFromRegistryFiles({
+			source: 'genesis_29-2',
+			destination: 'osmosis-1',
+			chainsData,
+			files: [{ name: 'genesisl1-osmosis.json', data: genesisOsmosis }],
+		});
+
+		expect(result.source).toEqual({
+			name: 'genesisl1',
+			chainId: 'genesis_29-2',
+		});
+		expect(result.destination).toEqual({
+			name: 'osmosis',
+			chainId: 'osmosis-1',
+		});
+		expect(result.links.map((link) => link.channelId)).toEqual(['channel-1', 'channel-0']);
+		expect(result.links[0]).toEqual({
+			sourceChainName: 'genesisl1',
+			sourceChainId: 'genesis_29-2',
+			destinationChainName: 'osmosis',
+			destinationChainId: 'osmosis-1',
+			channelId: 'channel-1',
+			portId: 'transfer',
+			counterpartyChannelId: 'channel-253',
+			counterpartyPortId: 'transfer',
+			clientId: '07-tendermint-1',
+			counterpartyClientId: '07-tendermint-1983',
+			connectionId: 'connection-1',
+			counterpartyConnectionId: 'connection-1539',
+			ordering: 'unordered',
+			version: 'ics20-1',
+			tags: {
+				status: 'ACTIVE',
+				preferred: true,
+				dex: 'osmosis',
+			},
+			sourceFile: 'genesisl1-osmosis.json',
+		});
+	});
+
+	it('maps the same registry file in reverse when source and destination are swapped', () => {
+		const result = resolveIbcLinksFromRegistryFiles({
+			source: 'osmosis',
+			destination: 'genesisl1',
+			chainsData,
+			files: [{ name: 'genesisl1-osmosis.json', data: genesisOsmosis }],
+		});
+
+		expect(result.links[0]).toMatchObject({
+			sourceChainName: 'osmosis',
+			destinationChainName: 'genesisl1',
+			channelId: 'channel-253',
+			counterpartyChannelId: 'channel-1',
+			clientId: '07-tendermint-1983',
+			counterpartyClientId: '07-tendermint-1',
+		});
+	});
+
+	it('uses channel-level client and connection overrides when registry channels provide them', () => {
+		const result = resolveIbcLinksFromRegistryFiles({
+			source: 'genesisl1',
+			destination: 'osmosis',
+			chainsData,
+			files: [
+				{
+					name: 'genesisl1-osmosis.json',
+					data: {
+						chain_1: {
+							chain_name: 'genesisl1',
+							client_id: '07-tendermint-1',
+							connection_id: 'connection-1',
+						},
+						chain_2: {
+							chain_name: 'osmosis',
+							client_id: '07-tendermint-1983',
+							connection_id: 'connection-1539',
+						},
+						channels: [
+							{
+								chain_1: {
+									channel_id: 'channel-69',
+									port_id: 'transfer',
+									client_id: '07-tendermint-103',
+									connection_id: 'connection-89',
+								},
+								chain_2: {
+									channel_id: 'channel-61',
+									port_id: 'transfer',
+									client_id: '07-tendermint-120',
+									connection_id: 'connection-93',
+								},
+								ordering: 'unordered',
+								version: 'ics20-1',
+								tags: {
+									preferred: true,
+									status: 'ACTIVE',
+								},
+							},
+						],
+					},
+				},
+			],
+		});
+
+		expect(result.links[0]).toMatchObject({
+			clientId: '07-tendermint-103',
+			connectionId: 'connection-89',
+			counterpartyClientId: '07-tendermint-120',
+			counterpartyConnectionId: 'connection-93',
+		});
+	});
+
+	it('surfaces matching IBC registry file fetch failures', async () => {
+		clearIbcLinkCaches();
+		const fetchFn = async (url: string | URL | Request) => {
+			const textUrl = String(url);
+			if (textUrl.includes('/contents/_IBC')) {
+				return Response.json([
+					{
+						name: 'genesisl1-osmosis.json',
+						type: 'file',
+						download_url: 'https://raw.example.com/genesisl1-osmosis.json',
+					},
+				]);
+			}
+
+			return new Response('unavailable', { status: 503 });
+		};
+
+		await expect(
+			resolveIbcLinksFromChainRegistry({
+				source: 'genesisl1',
+				destination: 'osmosis',
+				chainsData,
+				fetchFn: fetchFn as typeof fetch,
+				now: () => 1700000000000,
+			})
+		).rejects.toThrow(/HTTP 503/);
+	});
+});


### PR DESCRIPTION
## Summary
- add /api/ibc-links for resolving source/destination chain pairs by name or chain ID
- map preferred ACTIVE transfer links from chain-registry _IBC data, including channel-level client/connection overrides
- propagate matching IBC file fetch failures instead of returning empty successful results

## Verification
- bun test tests/ibcLinks.test.ts
- bun test
- bun run lint
- bun run build
- local probe: /api/ibc-links?source=genesis_29-2&destination=osmosis-1 resolves genesisl1 channel-1 -> osmosis channel-253
- second-pass explorer review: no blocking issues